### PR TITLE
feat 광고 수정하기 및 만들기 페이지 생성, 라우팅 처리

### DIFF
--- a/src/components/ad/AdManageContent.tsx
+++ b/src/components/ad/AdManageContent.tsx
@@ -28,7 +28,7 @@ const AdManageContent = () => {
             <MenuItem value={30}>광고3</MenuItem>
           </Select>
         </FormControl>
-        <Link href="/ad" underline="none">
+        <Link href="/ad_make" underline="none">
           광고 만들기
         </Link>
       </Box>

--- a/src/components/ad/AdManageItem.tsx
+++ b/src/components/ad/AdManageItem.tsx
@@ -11,8 +11,10 @@ import {
   Button,
   Grid,
 } from "@mui/material";
+import { useNavigate } from "react-router-dom";
 
 const AdManageItem = () => {
+  const navigate = useNavigate();
   return (
     <StyledAdListWrap item xs={2} sm={4} md={4}>
       <CardContent>
@@ -53,7 +55,12 @@ const AdManageItem = () => {
             <ListItemText primary="Single-line item" />
           </ListItem>
         </List>
-        <Button variant="outlined" color="info" sx={{ mt: 2 }}>
+        <Button
+          variant="outlined"
+          color="info"
+          sx={{ mt: 2 }}
+          onClick={() => navigate("/ad_modify")}
+        >
           수정하기
         </Button>
       </CardContent>

--- a/src/pages/AdMake.tsx
+++ b/src/pages/AdMake.tsx
@@ -1,0 +1,101 @@
+import Layout from "../components/layout/Layout";
+import { Box, styled, Typography, Input, Button } from "@mui/material";
+import { useNavigate } from "react-router-dom";
+
+const AdModify = () => {
+  const ariaLabel = { "aria-label": "description" };
+  const navigate = useNavigate();
+  return (
+    <Layout>
+      <StyledContents>
+        <Typography variant="h6" sx={{ mb: 2 }}>
+          광고관리
+        </Typography>
+        <Box sx={{ flexGrow: 1 }}>
+          <Title>광고 만들기</Title>
+          <AddForm>
+            <InputBox>
+              <Input
+                placeholder="타이틀"
+                inputProps={ariaLabel}
+                autoFocus={true}
+              />
+              <Input placeholder="상태" inputProps={ariaLabel} />
+              <Input placeholder="광고 생성일" inputProps={ariaLabel} />
+              <Input placeholder="일 희망 예산" inputProps={ariaLabel} />
+              <Input placeholder="광고 수익률" inputProps={ariaLabel} />
+              <Input placeholder="매출" inputProps={ariaLabel} />
+              <Input placeholder="광고 비용" inputProps={ariaLabel} />
+            </InputBox>
+          </AddForm>
+          <ButtonBox>
+            <Button
+              variant="contained"
+              style={{
+                borderRadius: 12,
+                backgroundColor: "#727272",
+                padding: "0 1.5rem",
+              }}
+              onClick={() => navigate("/ad")}
+            >
+              목록으로
+            </Button>
+            <Button
+              variant="contained"
+              style={{
+                borderRadius: 12,
+                backgroundColor: "#586CF5",
+                padding: "0 1.5rem",
+              }}
+            >
+              광고 만들기
+            </Button>
+          </ButtonBox>
+        </Box>
+      </StyledContents>
+    </Layout>
+  );
+};
+
+export default AdModify;
+
+const StyledContents = styled(Box)({
+  paddingBlock: 50,
+  paddingInline: 40,
+});
+const Title = styled("header")({
+  textAlign: "center",
+  fontWeight: "700",
+  fontSize: "1.5rem",
+  color: "#4e4e4e",
+  margin: "3rem 0",
+});
+const AddForm = styled("div")({
+  backgroundColor: "pink",
+  width: "31rem",
+  height: "37rem",
+  background: "#ffffff",
+  boxShadow: "5px 5px 10px 5px rgba(0, 0, 0, 0.25)",
+  borderRadius: "3rem",
+  margin: "0 auto",
+  position: "relative",
+});
+const ButtonBox = styled("div")({
+  width: "30rem",
+  height: "2.5rem",
+  display: "flex",
+  justifyContent: "space-between",
+  margin: "0 auto",
+  marginTop: "5rem",
+});
+const InputBox = styled("div")({
+  width: "25rem",
+  height: "37rem",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "space-between",
+  color: "#acacac",
+  padding: "6rem 2rem",
+  boxSizing: "border-box",
+  margin: "0 auto",
+});

--- a/src/pages/AdModify.tsx
+++ b/src/pages/AdModify.tsx
@@ -1,0 +1,101 @@
+import Layout from "../components/layout/Layout";
+import { Box, styled, Typography, Input, Button } from "@mui/material";
+import { useNavigate } from "react-router-dom";
+
+const AdModify = () => {
+  const ariaLabel = { "aria-label": "description" };
+  const navigate = useNavigate();
+  return (
+    <Layout>
+      <StyledContents>
+        <Typography variant="h6" sx={{ mb: 2 }}>
+          광고관리
+        </Typography>
+        <Box sx={{ flexGrow: 1 }}>
+          <Title>광고 수정하기</Title>
+          <AddForm>
+            <InputBox>
+              <Input
+                placeholder="타이틀"
+                inputProps={ariaLabel}
+                autoFocus={true}
+              />
+              <Input placeholder="상태" inputProps={ariaLabel} />
+              <Input placeholder="광고 생성일" inputProps={ariaLabel} />
+              <Input placeholder="일 희망 예산" inputProps={ariaLabel} />
+              <Input placeholder="광고 수익률" inputProps={ariaLabel} />
+              <Input placeholder="매출" inputProps={ariaLabel} />
+              <Input placeholder="광고 비용" inputProps={ariaLabel} />
+            </InputBox>
+          </AddForm>
+          <ButtonBox>
+            <Button
+              variant="contained"
+              style={{
+                borderRadius: 12,
+                backgroundColor: "#727272",
+                padding: "0 1.5rem",
+              }}
+              onClick={() => navigate("/ad")}
+            >
+              목록으로
+            </Button>
+            <Button
+              variant="contained"
+              style={{
+                borderRadius: 12,
+                backgroundColor: "#586CF5",
+                padding: "0 1.5rem",
+              }}
+            >
+              수정하기
+            </Button>
+          </ButtonBox>
+        </Box>
+      </StyledContents>
+    </Layout>
+  );
+};
+
+export default AdModify;
+
+const StyledContents = styled(Box)({
+  paddingBlock: 50,
+  paddingInline: 40,
+});
+const Title = styled("header")({
+  textAlign: "center",
+  fontWeight: "700",
+  fontSize: "1.5rem",
+  color: "#4e4e4e",
+  margin: "3rem 0",
+});
+const AddForm = styled("div")({
+  backgroundColor: "pink",
+  width: "31rem",
+  height: "37rem",
+  background: "#ffffff",
+  boxShadow: "5px 5px 10px 5px rgba(0, 0, 0, 0.25)",
+  borderRadius: "3rem",
+  margin: "0 auto",
+  position: "relative",
+});
+const ButtonBox = styled("div")({
+  width: "30rem",
+  height: "2.5rem",
+  display: "flex",
+  justifyContent: "space-between",
+  margin: "0 auto",
+  marginTop: "5rem",
+});
+const InputBox = styled("div")({
+  width: "25rem",
+  height: "37rem",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "space-between",
+  color: "#acacac",
+  padding: "6rem 2rem",
+  boxSizing: "border-box",
+  margin: "0 auto",
+});

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -3,6 +3,8 @@ import { BrowserRouter } from "react-router-dom";
 import { Route, Routes } from "react-router-dom";
 import Dashboard from "../pages/Dashboard";
 import AdManage from "../pages/AdManege";
+import AdMake from "../pages/AdMake";
+import AdModify from "../pages/AdModify";
 import { ThemeProvider } from "@mui/material";
 import { theme } from "../styles/theme";
 
@@ -13,6 +15,8 @@ const Router = () => {
         <Routes>
           <Route path="/" element={<Dashboard />} />
           <Route path="/ad" element={<AdManage />} />
+          <Route path="/ad_make" element={<AdMake />} />
+          <Route path="/ad_modify" element={<AdModify />} />
         </Routes>
         {/* <Charts /> */}
       </ThemeProvider>


### PR DESCRIPTION
## 작업 내용
- 광고관리에서 이동되는 페이지인 광고 만들기,광고 수정하기 페이지 추가
- index 파일에서 라우트 처리 추가
- 광고관리 페이지 내 버튼에 navigate,Link로 페이지 이동 구현
---
## 추가사항
- AdMake , AdModify 로 파일명 작성했는데 괜찮은지 의견 부탁드립니다