### PR TITLE
feat: Create a utility function that sums the data of each channel

### DIFF
--- a/src/types/platform.d.ts
+++ b/src/types/platform.d.ts
@@ -1,5 +1,5 @@
 export interface PlatformItem {
-  channel: string;
+  channel: keyof Channel;
   date: string;
   imp: number;
   click: number;
@@ -11,6 +11,25 @@ export interface PlatformItem {
   cpa: number;
   roas: number;
 }
+
+type Channel = {
+  facebook: number;
+  google: number;
+  kakao: number;
+  naver: number;
+};
+
+export type PlatformAdData = {
+  imp: Channel;
+  cost: Channel;
+  click: Channel;
+  roas: Channel;
+  convValue: Channel;
+  ctr: Channel;
+  cvr: Channel;
+  cpc: Channel;
+  cpa: Channel;
+};
 
 export type PlatformItems = PlatformItem[];
 

--- a/src/util/getPlatformValues.ts
+++ b/src/util/getPlatformValues.ts
@@ -1,0 +1,79 @@
+import ChannelReport from "../data/channel-report.json";
+import { PlatformAdData, PlatformItems } from "../types/platform";
+
+const adDataKeyNameList = [
+  "imp",
+  "cost",
+  "click",
+  "roas",
+  "convValue",
+  "ctr",
+  "cpc",
+  "cpa",
+] as (keyof PlatformAdData)[];
+
+// TODO: 각 adData에 대해 name이 match되게끔 데이터 구조 수정
+// TYPE 지정 필요
+const adDataChartNameList = [
+  "노출수",
+  "광고단가",
+  "클릭수",
+  "매출수",
+  "전환수",
+  "클릭율",
+  "클릭단가",
+  "전환단가",
+];
+
+const createIntialCompanyData = () => ({
+  facebook: 0,
+  google: 0,
+  kakao: 0,
+  naver: 0,
+});
+
+export const getPlatformValues = (dateRange: string[]) => {
+  // TODO: 백에서 해당 DATA 처리해줄 시
+  // 제거 + 받아온 데이터 PlatformItems로 type assertion
+  const receivedDateReduce = dateRange.reduce<PlatformItems>((acc, current) => {
+    if (current) {
+      const values = ChannelReport.filter(
+        (value) => String(value.date) === String(current)
+      ) as PlatformItems;
+      acc.push(...values);
+    }
+    return acc;
+  }, []);
+
+  const initialCompanyAdData = adDataKeyNameList.reduce(
+    (companyAdData, name) => {
+      companyAdData[name] = createIntialCompanyData();
+      return companyAdData;
+    },
+    {} as PlatformAdData
+  );
+
+  // TODO: data 종류(imp, roas 등등)에 따라 작업 다르게 진행
+  // 현재는 sum만 돌림 -> 평균값 구해야 하는 애들의 경우 기간으로 나누기 필요
+  const companyDataSum = receivedDateReduce.reduce<PlatformAdData>(
+    (acc, curr) => {
+      const { channel } = curr;
+
+      adDataKeyNameList.forEach((name) => {
+        const adDataValue = curr[name];
+        acc[name][channel] += adDataValue;
+      });
+
+      return acc;
+    },
+    initialCompanyAdData
+  );
+
+  // TODO: adDataChartNameList data를 hash로 변경 후 로직 수정
+  const companyAdData = adDataChartNameList.map((chart, idx) => {
+    const chartData = adDataKeyNameList[idx];
+    return { name: chart, [chartData]: companyDataSum[chartData] };
+  });
+
+  return companyAdData;
+};


### PR DESCRIPTION
## 작업 설명

`getPlatformValues` util 함수
- date 기준(하루, 한달)에 따라 들어온 데이터들을 이용해, 각 채널에 대해 데이터의 합산을 구하기
- mui chart에서 이용할 수 있게끔 데이터 구조를 해시로 구현
   - ex. { name: '노출수', imp: {google: ~, kakao: ~ ...} }

## 보안 사항
- 백에서 data를 date 기준으로 리스트를 보내줄 시 receivedDateReduce 제거
- data 종류(imp, roas 등등..)에 따라 합산 or 평균값 구하는 작업 처리
  - 현재는 합산만 구한 상황
  - data 종류에 따라 date 기간으로 나누는 추가 작업하기 (api가 완성되면 구현할 예정)
- 각 ad data 이름을 저장해둔 adDataChartNameList 데이터 구조 수정
  - type 지정 + companyAdData 로직 수정
  
  
close #24 