### PR TITLE
fix 수정하기 페이지와 만들기 페이지 공통 컴포넌트 분리에서 버그발생 -> 다시 페이지별로 내용 이동

### DIFF
--- a/src/api/instance/instance.ts
+++ b/src/api/instance/instance.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { httpRequest } from '../http/httpRequest';
+import { httpRequest } from '../http/HttpRequest';
 
 const axiosInstance = axios.create({
   baseURL: 'http://localhost:8000',

--- a/src/components/campaign/CampaignForm.tsx
+++ b/src/components/campaign/CampaignForm.tsx
@@ -1,30 +1,56 @@
-import React from "react";
-import { Box, styled, Input, Button,TextField } from "@mui/material";
-import { useNavigate } from "react-router-dom";
-// import {useRecoilState} from 'recoil'
-// import { campaignRequestType } from "../../store/campaign";
+import React, { useEffect, useRef } from 'react';
+import { Box, styled, Input, Button, TextField } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
 
 interface TypeProps {
   type: string;
-  campaignDataById:number;
+  campaignDataById: number;
 }
 
-const CampaignForm = ({ type,campaignDataById }: any) => {
-  console.log(campaignDataById);
-  const {id,adType,title,budget,status,startDate,endDate,report} = campaignDataById;
-  // const [title, setTitle] = React.useState(`${campaignDataById.title}`);
-  // const [status, setStatus] = React.useState(`${campaignDataById.status}`);
-  // const [date, setDate] = React.useState(`${campaignDataById.startDate.substr(0, 10)}`);
-  // const [budget, setBudget] = React.useState(`${campaignDataById.budget.toLocaleString()}`);
-  // const [roas, setRoas] = React.useState(`${campaignDataById.report.roas}`);
-  // const [convValue, setConvValue] = React.useState(`${campaignDataById.report.convValue.toLocaleString()}`);
-  // const [cost, setCost] = React.useState(`${campaignDataById.report.cost.toLocaleString()}`);
+const CampaignForm = ({ type, campaignDataById }: any) => {
+  const [previousTitle, setPreviousTitle] = React.useState('');
+  const [previousStatus, setStatus] = React.useState('');
+  const [previousDate, setDate] = React.useState('');
+  const [previousBudget, setBudget] = React.useState('');
+  const [previousRoas, setRoas] = React.useState('');
+  const [previousConvValue, setConvValue] = React.useState('');
+  const [previousCost, setCost] = React.useState('');
 
-  const handleChange=()=>{
-    console.log('test');
-  }
-  const ariaLabel = { "aria-label": "description" };
+  const titleRef = useRef<HTMLInputElement | any>(null);
+  const statusRef = useRef<HTMLDivElement | any>(null);
+  const dateRef = useRef<HTMLDivElement | any>(null);
+  const budgetRef = useRef<HTMLDivElement | any>(null);
+  const roasRef = useRef<HTMLDivElement | any>(null);
+  const convValueRef = useRef<HTMLDivElement | any>(null);
+  const costRef = useRef<HTMLDivElement | any>(null);
+
+  useEffect(() => {
+    if (campaignDataById === null) {
+      console.log('만들기페이지 버그 수정');
+      setPreviousTitle(titleRef.current.value);
+      setStatus(statusRef.current.value);
+      setDate(dateRef.current.value);
+      setBudget(budgetRef.current.value);
+      setRoas(roasRef.current.value);
+      setConvValue(convValueRef.current.value);
+      setCost(costRef.current.value);
+    } else {
+      setPreviousTitle(`${campaignDataById.title}`);
+      setStatus(`${campaignDataById.status}`);
+      setDate(`${campaignDataById.startDate}}`);
+      setBudget(`${campaignDataById.budget}`);
+      setRoas(`${campaignDataById.report.roas}`);
+      setConvValue(`${campaignDataById.report.convValue}`);
+      setCost(`${campaignDataById.cost}`);
+    }
+  });
+  const handleChange = (event: any): any => {
+    console.log(event.target.value);
+    setPreviousTitle(event.target.value);
+  };
+  const ariaLabel = { 'aria-label': 'description' };
   const navigate = useNavigate();
+
   return (
     <>
       <Box sx={{ flexGrow: 1 }}>
@@ -35,16 +61,65 @@ const CampaignForm = ({ type,campaignDataById }: any) => {
               id="standard-multiline-flexible"
               label="제목"
               multiline
-              value={title}
+              value={previousTitle}
+              ref={titleRef}
               onChange={handleChange}
               variant="standard"
             />
-            <Input placeholder="상태" inputProps={ariaLabel} value={status}/>
-            <Input placeholder="광고 생성일" inputProps={ariaLabel} value={startDate}/>
-            <Input placeholder="일 희망 예산" inputProps={ariaLabel} value={budget} />
-            <Input placeholder="광고 수익률" inputProps={ariaLabel} value={report.roas}/>
-            <Input placeholder="매출" inputProps={ariaLabel} value={report.convValue}/>
-            <Input placeholder="광고 비용" inputProps={ariaLabel} value={report.cost}/>
+            <TextField
+              id="standard-multiline-flexible"
+              label="상태"
+              multiline
+              value={previousStatus}
+              ref={statusRef}
+              onChange={handleChange}
+              variant="standard"
+            />
+            <TextField
+              id="standard-multiline-flexible"
+              label="광고 생성일"
+              multiline
+              value={previousDate}
+              ref={dateRef}
+              onChange={handleChange}
+              variant="standard"
+            />
+            <TextField
+              id="standard-multiline-flexible"
+              label="일 희망 예산"
+              multiline
+              value={previousBudget}
+              ref={budgetRef}
+              onChange={handleChange}
+              variant="standard"
+            />
+            <TextField
+              id="standard-multiline-flexible"
+              label="광고 수익률"
+              multiline
+              value={previousRoas}
+              ref={roasRef}
+              onChange={handleChange}
+              variant="standard"
+            />
+            <TextField
+              id="standard-multiline-flexible"
+              label="매출"
+              multiline
+              value={previousConvValue}
+              ref={convValueRef}
+              onChange={handleChange}
+              variant="standard"
+            />
+            <TextField
+              id="standard-multiline-flexible"
+              label="광고 비용"
+              multiline
+              value={previousCost}
+              ref={costRef}
+              onChange={handleChange}
+              variant="standard"
+            />
           </InputBox>
         </AddForm>
         <ButtonBox>
@@ -52,10 +127,10 @@ const CampaignForm = ({ type,campaignDataById }: any) => {
             variant="contained"
             style={{
               borderRadius: 12,
-              backgroundColor: "#727272",
-              padding: "0 1.5rem",
+              backgroundColor: '#727272',
+              padding: '0 1.5rem',
             }}
-            onClick={() => navigate("/campaign-manage")}
+            onClick={() => navigate('/campaign-manage')}
           >
             목록으로
           </Button>
@@ -63,8 +138,8 @@ const CampaignForm = ({ type,campaignDataById }: any) => {
             variant="contained"
             style={{
               borderRadius: 12,
-              backgroundColor: "#586CF5",
-              padding: "0 1.5rem",
+              backgroundColor: '#586CF5',
+              padding: '0 1.5rem',
             }}
           >
             {`${type}`}
@@ -77,39 +152,39 @@ const CampaignForm = ({ type,campaignDataById }: any) => {
 
 export default CampaignForm;
 
-const Title = styled("header")({
-  textAlign: "center",
-  fontWeight: "700",
-  fontSize: "1.5rem",
-  color: "#4e4e4e",
-  margin: "1rem 0",
+const Title = styled('header')({
+  textAlign: 'center',
+  fontWeight: '700',
+  fontSize: '1.5rem',
+  color: '#4e4e4e',
+  margin: '1rem 0',
 });
-const AddForm = styled("div")({
-  backgroundColor: "pink",
-  width: "30rem",
-  height: "36rem",
-  background: "#ffffff",
-  boxShadow: "5px 5px 10px 5px rgba(0, 0, 0, 0.25)",
-  borderRadius: "3rem",
-  margin: "0 auto",
-  position: "relative",
+const AddForm = styled('div')({
+  backgroundColor: 'pink',
+  width: '30rem',
+  height: '36rem',
+  background: '#ffffff',
+  boxShadow: '5px 5px 10px 5px rgba(0, 0, 0, 0.25)',
+  borderRadius: '3rem',
+  margin: '0 auto',
+  position: 'relative',
 });
-const ButtonBox = styled("div")({
-  width: "30rem",
-  height: "2.5rem",
-  display: "flex",
-  justifyContent: "space-between",
-  margin: "0 auto",
-  marginTop: "2rem",
+const ButtonBox = styled('div')({
+  width: '30rem',
+  height: '2.5rem',
+  display: 'flex',
+  justifyContent: 'space-between',
+  margin: '0 auto',
+  marginTop: '2rem',
 });
-const InputBox = styled("div")({
-  width: "25rem",
-  height: "37rem",
-  display: "flex",
-  flexDirection: "column",
-  justifyContent: "space-between",
-  color: "#acacac",
-  padding: "6rem 2rem",
-  boxSizing: "border-box",
-  margin: "0 auto",
+const InputBox = styled('div')({
+  width: '25rem',
+  height: '37rem',
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'space-between',
+  color: '#acacac',
+  padding: '6rem 2rem',
+  boxSizing: 'border-box',
+  margin: '0 auto',
 });

--- a/src/components/campaign/ManageList.tsx
+++ b/src/components/campaign/ManageList.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React from 'react';
 import {
   Box,
   styled,
@@ -7,45 +7,60 @@ import {
   MenuItem,
   Link,
   Grid,
-} from "@mui/material";
-import ManageItem from "./ManageItem";
-import CampaignList from "../../data/campaign-list.json";
-import axios from "axios";
+  Button,
+} from '@mui/material';
+import ManageItem from './ManageItem';
+import CampaignList from '../../data/campaign-list.json';
+import { useNavigate } from 'react-router-dom';
 
 const ManageList = () => {
+  const navigate = useNavigate();
   const campaignList = CampaignList.ads;
   const [sortedList, setSortedList] = React.useState('');
 
-    const sortedCampaign = campaignList.filter((word) =>
-      (sortedList !== '' 
-      ? word.status === sortedList
-      : word
-      )
-    );
-    const sortCampaignStatus = (event: any): any => {
-      setSortedList(event.target.value);
+  const sortedCampaign = campaignList.filter(word =>
+    sortedList !== '' ? word.status === sortedList : word,
+  );
+  const sortCampaignStatus = (event: any): any => {
+    setSortedList(event.target.value);
   };
-  
+
   return (
     <StyledItem>
-      <Box sx={{ display: "flex", justifyContent: "space-between", mb: 3 }}>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          mb: 3,
+        }}
+      >
         <FormControl sx={{ minWidth: 120 }} size="small">
           <Select
             value={sortedList}
             displayEmpty
             onChange={sortCampaignStatus}
-            inputProps={{ "aria-label": "Without label" }}
+            inputProps={{ 'aria-label': 'Without label' }}
           >
             <MenuItem value="">
               <em>전체 광고</em>
             </MenuItem>
-            <MenuItem value={"active"}>진행중</MenuItem>
-            <MenuItem value={"ended"}>종료</MenuItem>
+            <MenuItem value={'active'}>진행중</MenuItem>
+            <MenuItem value={'ended'}>종료</MenuItem>
           </Select>
         </FormControl>
-        <Link href="/campaign-create" underline="none">
+        {/* <Link href="/campaign-create" underline="none">
+         */}
+        <Button
+          variant="outlined"
+          color="primary"
+          sx={{ mt: 2 }}
+          onClick={() => {
+            navigate(`/campaign-create`, { state: '' });
+          }}
+        >
           광고 만들기
-        </Link>
+        </Button>
+        {/* </Link> */}
       </Box>
       <Grid container spacing={2}>
         <ManageItem props={sortedCampaign} />
@@ -59,11 +74,11 @@ export default ManageList;
 const StyledItem = styled(Box)(({ theme }) => ({
   paddingBlock: 30,
   paddingInline: 35,
-  [theme.breakpoints.down("md")]: {
+  [theme.breakpoints.down('md')]: {
     marginTop: 20,
     paddingInline: 16,
   },
-  background: "#fff",
+  background: '#fff',
   minHeight: 400,
   borderRadius: 5,
 }));

--- a/src/pages/CreateCampaign.tsx
+++ b/src/pages/CreateCampaign.tsx
@@ -181,7 +181,7 @@ const CreateCampaign = (match: object) => {
               padding: '0 1.5rem',
             }}
           >
-            수정하기
+            광고 만들기
           </Button>
         </ButtonBox>
       </Box>

--- a/src/pages/CreateCampaign.tsx
+++ b/src/pages/CreateCampaign.tsx
@@ -1,12 +1,228 @@
-import Layout from "../components/layout/Layout";
-import CampaignForm from "../components/campaign/CampaignForm";
+import Layout from '../components/layout/Layout';
+import CampaignForm from '../components/campaign/CampaignForm';
+import { useLocation } from 'react-router-dom';
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  Box,
+  styled,
+  Input,
+  Button,
+  TextField,
+  FormControl,
+  Select,
+  MenuItem,
+  InputLabel,
+} from '@mui/material';
+import { useNavigate } from 'react-router-dom';
 
-const CreateCampaign = () => {
+const CreateCampaign = (match: object) => {
+  const location = useLocation();
+  console.log('state', location.state);
+  const [inputs, setInputs] = useState({
+    title: '',
+    status: '',
+    date: '',
+    budget: '',
+    roas: '',
+    convValue: '',
+    cost: '',
+  });
+  const { title, status, date, budget, roas, convValue, cost } =
+    inputs;
+
+  const titleRef = useRef<HTMLInputElement | any>(null);
+  const statusRef = useRef<HTMLDivElement | any>(null);
+  const startDateRef = useRef<HTMLDivElement | any>(null);
+  const endDateRef = useRef<HTMLDivElement | any>(null);
+  const budgetRef = useRef<HTMLDivElement | any>(null);
+  const roasRef = useRef<HTMLDivElement | any>(null);
+  const convValueRef = useRef<HTMLDivElement | any>(null);
+  const costRef = useRef<HTMLDivElement | any>(null);
+
+  const [type, setType] = React.useState('');
+  const [postedStatus, setPostedStatus] = React.useState('');
+
+  const handleChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const { value, name } = event.target;
+    console.log(value);
+    setInputs({
+      ...inputs,
+      [name]: value,
+    });
+  };
+  const handleCampaignType = (event: any) => {
+    setType(event.target.value);
+  };
+  const handleCampaignStatus = (event: any) => {
+    setPostedStatus(event.target.value);
+  };
+
+  const ariaLabel = { 'aria-label': 'description' };
+  const navigate = useNavigate();
   return (
     <Layout>
-      <CampaignForm type="만들기" />
+      {/* <CampaignForm type="만들기" campaignDataById={location.state} /> */}
+      <Box sx={{ flexGrow: 1 }}>
+        <Title>광고 만들기</Title>
+        <AddForm>
+          <InputBox>
+            <TextField
+              id="standard-multiline-flexible"
+              label="제목"
+              multiline
+              // value={title}
+              ref={titleRef}
+              onChange={handleChange}
+              variant="standard"
+            />
+            <FormControl
+              sx={{ minWidth: 120, marginTop: 2 }}
+              size="small"
+            >
+              <Select
+                value={type}
+                onChange={handleCampaignType}
+                displayEmpty
+                inputProps={{ 'aria-label': 'Without label' }}
+              >
+                <MenuItem value="">
+                  <em>광고 타입</em>
+                </MenuItem>
+                <MenuItem value={'WEB'}>WEB</MenuItem>
+                <MenuItem value={'APP'}>APP</MenuItem>
+              </Select>
+            </FormControl>
+            <TextField
+              id="standard-multiline-flexible"
+              label="일 희망 예산"
+              multiline
+              ref={budgetRef}
+              onChange={handleChange}
+              variant="standard"
+            />
+            <FormControl
+              sx={{ minWidth: 120, marginTop: 2 }}
+              size="small"
+            >
+              <Select
+                value={postedStatus}
+                onChange={handleCampaignStatus}
+                displayEmpty
+                inputProps={{ 'aria-label': 'Without label' }}
+              >
+                <MenuItem value="">
+                  <em>광고 상태</em>
+                </MenuItem>
+                <MenuItem value={'ACTIVE'}>ACTIVE</MenuItem>
+                <MenuItem value={'ENDED'}>ENDED</MenuItem>
+              </Select>
+            </FormControl>
+            <TextField
+              id="standard-multiline-flexible"
+              label="광고 생성일"
+              multiline
+              ref={startDateRef}
+              onChange={handleChange}
+              variant="standard"
+            />
+            <TextField
+              id="standard-multiline-flexible"
+              label="광고 마감일"
+              multiline
+              ref={endDateRef}
+              onChange={handleChange}
+              variant="standard"
+            />
+            <TextField
+              id="standard-multiline-flexible"
+              label="광고 비용"
+              multiline
+              ref={costRef}
+              onChange={handleChange}
+              variant="standard"
+            />
+            <TextField
+              id="standard-multiline-flexible"
+              label="매출"
+              multiline
+              ref={convValueRef}
+              onChange={handleChange}
+              variant="standard"
+            />
+            <TextField
+              id="standard-multiline-flexible"
+              label="광고 수익률"
+              multiline
+              ref={roasRef}
+              onChange={handleChange}
+              variant="standard"
+            />
+          </InputBox>
+        </AddForm>
+        <ButtonBox>
+          <Button
+            variant="contained"
+            style={{
+              borderRadius: 12,
+              backgroundColor: '#727272',
+              padding: '0 1.5rem',
+            }}
+            onClick={() => navigate('/campaign-manage')}
+          >
+            목록으로
+          </Button>
+          <Button
+            variant="contained"
+            style={{
+              borderRadius: 12,
+              backgroundColor: '#586CF5',
+              padding: '0 1.5rem',
+            }}
+          >
+            수정하기
+          </Button>
+        </ButtonBox>
+      </Box>
     </Layout>
   );
 };
 
 export default CreateCampaign;
+const Title = styled('header')({
+  textAlign: 'center',
+  fontWeight: '700',
+  fontSize: '1.5rem',
+  color: '#4e4e4e',
+  margin: '1rem 0',
+});
+const AddForm = styled('div')({
+  backgroundColor: 'pink',
+  width: '30rem',
+  height: '36rem',
+  background: '#ffffff',
+  boxShadow: '5px 5px 10px 5px rgba(0, 0, 0, 0.25)',
+  borderRadius: '3rem',
+  margin: '0 auto',
+  position: 'relative',
+});
+const ButtonBox = styled('div')({
+  width: '30rem',
+  height: '2.5rem',
+  display: 'flex',
+  justifyContent: 'space-between',
+  margin: '0 auto',
+  marginTop: '2rem',
+});
+const InputBox = styled('div')({
+  width: '25rem',
+  height: '37rem',
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'space-between',
+  color: '#acacac',
+  padding: '4rem 2rem',
+  boxSizing: 'border-box',
+  margin: '0 auto',
+});

--- a/src/pages/EditCampaign.tsx
+++ b/src/pages/EditCampaign.tsx
@@ -1,16 +1,204 @@
-import Layout from "../components/layout/Layout";
-import CampaignForm from "../components/campaign/CampaignForm";
+import Layout from '../components/layout/Layout';
+import CampaignForm from '../components/campaign/CampaignForm';
 import { useLocation } from 'react-router-dom';
+import React, { useEffect, useRef, useState } from 'react';
+import { Box, styled, Input, Button, TextField } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
 
-const EditCampaign = (match:object) => {
-  const location=useLocation();
-  console.log('state',location.state);
+const EditCampaign = (match: object) => {
+  const location = useLocation();
+  const compaignById: any = location.state;
+  console.log(compaignById);
+
+  // const [previousTitle, setPreviousTitle] = React.useState(
+  //   compaignById.title,
+  // );
+  // const [previousStatus, setStatus] = React.useState(
+  //   compaignById.status,
+  // );
+  // const [previousDate, setDate] = React.useState(
+  //   compaignById.startDate,
+  // );
+  // const [previousBudget, setBudget] = React.useState(
+  //   compaignById.budget,
+  // );
+  // const [previousRoas, setRoas] = React.useState(
+  //   compaignById.report.roas,
+  // );
+  // const [previousConvValue, setConvValue] = React.useState(
+  //   compaignById.report.convValue,
+  // );
+  // const [previousCost, setCost] = React.useState(
+  //   compaignById.report.cost,
+  // );
+
+  // const titleRef = useRef<HTMLInputElement | any>(null);
+  // const statusRef = useRef<HTMLDivElement | any>(null);
+  // const dateRef = useRef<HTMLDivElement | any>(null);
+  // const budgetRef = useRef<HTMLDivElement | any>(null);
+  // const roasRef = useRef<HTMLDivElement | any>(null);
+  // const convValueRef = useRef<HTMLDivElement | any>(null);
+  // const costRef = useRef<HTMLDivElement | any>(null);
+
+  const [inputs, setInputs] = useState({
+    title: compaignById.title,
+    status: compaignById.status,
+    date: compaignById.startDate,
+    budget: compaignById.budget,
+    roas: compaignById.report.roas,
+    convValue: compaignById.report.convValue,
+    cost: compaignById.report.cost,
+  });
+  const { title, status, date, budget, roas, convValue, cost } =
+    inputs;
+  const handleChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const { value, name } = event.target;
+    console.log(value);
+    setInputs({
+      ...inputs,
+      [name]: value,
+    });
+  };
+
+  const ariaLabel = { 'aria-label': 'description' };
+  const navigate = useNavigate();
 
   return (
     <Layout>
-      <CampaignForm type="수정하기" campaignDataById={location.state} />
+      {/* <CampaignForm type="수정하기" campaignDataById={location.state} /> */}
+      <Box sx={{ flexGrow: 1 }}>
+        <Title>광고 수정하기</Title>
+        <AddForm>
+          <InputBox>
+            <TextField
+              id="standard-multiline-flexible"
+              label="제목"
+              multiline
+              value={title}
+              // ref={titleRef}
+              onChange={handleChange}
+              variant="standard"
+            />
+            <TextField
+              id="standard-multiline-flexible"
+              label="상태"
+              multiline
+              value={status}
+              // ref={statusRef}
+              onChange={handleChange}
+              variant="standard"
+            />
+            <TextField
+              id="standard-multiline-flexible"
+              label="광고 생성일"
+              multiline
+              value={date}
+              // ref={dateRef}
+              onChange={handleChange}
+              variant="standard"
+            />
+            <TextField
+              id="standard-multiline-flexible"
+              label="일 희망 예산"
+              multiline
+              value={budget}
+              // ref={budgetRef}
+              onChange={handleChange}
+              variant="standard"
+            />
+            <TextField
+              id="standard-multiline-flexible"
+              label="광고 수익률"
+              multiline
+              value={roas}
+              // ref={roasRef}
+              onChange={handleChange}
+              variant="standard"
+            />
+            <TextField
+              id="standard-multiline-flexible"
+              label="매출"
+              multiline
+              value={convValue}
+              // ref={convValueRef}
+              onChange={handleChange}
+              variant="standard"
+            />
+            <TextField
+              id="standard-multiline-flexible"
+              label="광고 비용"
+              multiline
+              value={cost}
+              // ref={costRef}
+              onChange={handleChange}
+              variant="standard"
+            />
+          </InputBox>
+        </AddForm>
+        <ButtonBox>
+          <Button
+            variant="contained"
+            style={{
+              borderRadius: 12,
+              backgroundColor: '#727272',
+              padding: '0 1.5rem',
+            }}
+            onClick={() => navigate('/campaign-manage')}
+          >
+            목록으로
+          </Button>
+          <Button
+            variant="contained"
+            style={{
+              borderRadius: 12,
+              backgroundColor: '#586CF5',
+              padding: '0 1.5rem',
+            }}
+          >
+            수정하기
+          </Button>
+        </ButtonBox>
+      </Box>
     </Layout>
   );
 };
 
 export default EditCampaign;
+const Title = styled('header')({
+  textAlign: 'center',
+  fontWeight: '700',
+  fontSize: '1.5rem',
+  color: '#4e4e4e',
+  margin: '1rem 0',
+});
+const AddForm = styled('div')({
+  backgroundColor: 'pink',
+  width: '30rem',
+  height: '36rem',
+  background: '#ffffff',
+  boxShadow: '5px 5px 10px 5px rgba(0, 0, 0, 0.25)',
+  borderRadius: '3rem',
+  margin: '0 auto',
+  position: 'relative',
+});
+const ButtonBox = styled('div')({
+  width: '30rem',
+  height: '2.5rem',
+  display: 'flex',
+  justifyContent: 'space-between',
+  margin: '0 auto',
+  marginTop: '2rem',
+});
+const InputBox = styled('div')({
+  width: '25rem',
+  height: '37rem',
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'space-between',
+  color: '#acacac',
+  padding: '6rem 2rem',
+  boxSizing: 'border-box',
+  margin: '0 auto',
+});


### PR DESCRIPTION
### 작업내역

- 광고관리 페이지
    - 수정 및 등록 폼에서 Input → TextField로 변경
    - 수정하기 페이지와 만들기 페이지 공통 컴포넌트 분리에서 버그발생 -> 다시 페이지별로 내용 이동

### 작업파일

- ManageList
- CampaignForm
- CreateCampaign

### 작업 필요

1. 수정하기 onChange로 값 변경 가능하게
2. 수정하기에서 값 수정후 api에 patch보내서 카드에 수정된거 반영
3. 만들기에서 값 입력하면 해당 값 api에 post보내서 광고관리 페이지에 카드가 추가
4. type임시로 any지정해둔거 수정